### PR TITLE
chore: add optional field as null, check null is preserved

### DIFF
--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-test": "^0.0.7"
+        "@dylibso/xtp-test": "^0.0.8"
       },
       "devDependencies": {
         "@extism/js-pdk": "^1.0.0",
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@dylibso/xtp-test": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-test/-/xtp-test-0.0.7.tgz",
-      "integrity": "sha512-P0xYxMhdT/8M7va7h59YV/5vSp2ixvxi5zRKgXh1QCRwk+TEuzQ5I9qedqMtRWbkJwQK+Ak7kmi6qpldrG++QA=="
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-test/-/xtp-test-0.0.8.tgz",
+      "integrity": "sha512-XToSxuKdY4M2DFTPm09/6CtANeKmmNZyG8YLxS60bIRTmLV7mDyrILU+kXtCES5Ld041TGEtj3X1fXWNACRhzA=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/runner/package.json
+++ b/runner/package.json
@@ -15,6 +15,6 @@
     "@extism/js-pdk": "^1.0.0"
   },
   "dependencies": {
-    "@dylibso/xtp-test": "^0.0.7"
+    "@dylibso/xtp-test": "^0.0.8"
   }
 }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -3,39 +3,54 @@ import { Test } from "@dylibso/xtp-test";
 const EmbeddedObject = {
   aBoolArray: [true, false, true],
   aStringArray: ["Hello", "🌍", "World!"],
-  anEnumArray: ['option1', 'option2', 'option3'],
+  anEnumArray: ["option1", "option2", "option3"],
   anIntArray: [1, 2, 3],
-}
+};
 
 const KitchenSink = {
+  anOptionalString: null,
   aString: "🌍Hello 🌍 World!🌍",
   anInt: 42,
   aFloat: 3.14,
   aDouble: 3.141592653589793238462643383279502884197,
   aBool: true,
-  anUntypedObject: { hello: 'world' },
-  anEnum: 'option1',
+  anUntypedObject: { hello: "world" },
+  anEnum: "option1",
   anEmbeddedObject: EmbeddedObject,
-  anEmbeddedObjectArray: [EmbeddedObject, EmbeddedObject]
-}
+  anEmbeddedObjectArray: [EmbeddedObject, EmbeddedObject],
+};
 
 export function test() {
-  let input = JSON.stringify(KitchenSink)
-  let output = JSON.parse(Test.callString("reflectJsonObject", input))
+  let input = JSON.stringify(KitchenSink);
+  let output = JSON.parse(Test.callString("reflectJsonObject", input));
   // assuming if we re-stringify them here the formatting should be the same
-  Test.assertEqual("reflectJsonObject preserved the KitchenSink JSON object", JSON.stringify(output), JSON.stringify(KitchenSink))
+  Test.assertEqual(
+    "reflectJsonObject preserved the KitchenSink JSON object",
+    JSON.stringify(output),
+    JSON.stringify(KitchenSink),
+  );
 
-  let inputS = KitchenSink.aString
-  let outputS = Test.callString("reflectUtf8String", inputS)
-  Test.assertEqual("reflectUtf8String preserved the string", outputS, inputS)
+  Test.assertEqual(
+    "reflectJsonObject preserved optional field semantics",
+    output.anOptionalString,
+    KitchenSink.anOptionalString,
+  );
 
-  let inputB = (new TextEncoder()).encode(KitchenSink.aString).buffer
-  let outputBs = Test.call("reflectByteBuffer", inputB)
+  let inputS = KitchenSink.aString;
+  let outputS = Test.callString("reflectUtf8String", inputS);
+  Test.assertEqual("reflectUtf8String preserved the string", outputS, inputS);
+
+  let inputB = (new TextEncoder()).encode(KitchenSink.aString).buffer;
+  let outputBs = Test.call("reflectByteBuffer", inputB);
   // @ts-ignore TODO fix this when new xtp-test-js is pushed
-  let outputB = outputBs.readBytes()
+  let outputB = outputBs.readBytes();
 
   // TODO compare the bytes
-  Test.assertEqual("reflectByteBuffer preserved the buffer length", outputB.byteLength, inputB.byteLength)
+  Test.assertEqual(
+    "reflectByteBuffer preserved the buffer length",
+    outputB.byteLength,
+    inputB.byteLength,
+  );
 
   return 0;
 }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -42,7 +42,6 @@ export function test() {
 
   let inputB = (new TextEncoder()).encode(KitchenSink.aString).buffer;
   let outputBs = Test.call("reflectByteBuffer", inputB);
-  // @ts-ignore TODO fix this when new xtp-test-js is pushed
   let outputB = outputBs.readBytes();
 
   // TODO compare the bytes


### PR DESCRIPTION
This adds the `anOptionalString: null` to the KitchenSink variable and adds a test to see that null was preserved. 