### PR TITLE
feat: support more granular tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bundle
 bundle.zip
 exampleplugin
+**/.DS_Store

--- a/schema.yaml
+++ b/schema.yaml
@@ -16,7 +16,7 @@ exports:
             return KitchenSinkObject{}, err
           }
 
-	        return *reflect, err
+          return *reflect, err
     input:
       $ref: "#/schemas/KitchenSinkObject"
     output:

--- a/schema.yaml
+++ b/schema.yaml
@@ -9,6 +9,9 @@ exports:
         source: |
           // pass this through the host function and return it back
           return reflectJsonObjectHost(input)
+      - lang: go
+        source: |-
+          return input, nil
     input:
       $ref: "#/schemas/KitchenSinkObject"
     output:
@@ -21,6 +24,9 @@ exports:
       - lang: typescript
         source: |
           return reflectUtf8StringHost(input)
+      - lang: go
+        source: |-
+          return input, nil
     input:
       type: string
       description: The input string
@@ -37,6 +43,9 @@ exports:
       - lang: typescript
         source: |
           return reflectByteBufferHost(input)
+      - lang: go
+        source: |-
+          return input, nil
     input:
       type: buffer
       description: The input byte buffer
@@ -77,6 +86,7 @@ imports:
       description: The output byte buffer
 schemas:
   - name: EmbeddedObject
+    contentType: application/json
     description: An embedded object, has some arrays too
     required:
       - aBoolArray

--- a/schema.yaml
+++ b/schema.yaml
@@ -11,7 +11,12 @@ exports:
           return reflectJsonObjectHost(input)
       - lang: go
         source: |-
-          return input, nil
+          reflect, err := ReflectJsonObjectHost(input)
+          if err != nil {
+            return KitchenSinkObject{}, err
+          }
+
+	        return *reflect, err
     input:
       $ref: "#/schemas/KitchenSinkObject"
     output:
@@ -26,7 +31,12 @@ exports:
           return reflectUtf8StringHost(input)
       - lang: go
         source: |-
-          return input, nil
+          reflect, err := ReflectUtf8StringHost(input)
+          if err != nil {
+            return "", err
+          }
+
+          return *reflect, nil
     input:
       type: string
       description: The input string
@@ -45,7 +55,12 @@ exports:
           return reflectByteBufferHost(input)
       - lang: go
         source: |-
-          return input, nil
+          reflect, err := ReflectByteBufferHost(input)
+          if err != nil {
+            return nil, err
+          }
+
+          return reflect, nil
     input:
       type: buffer
       description: The input byte buffer


### PR DESCRIPTION
This was in large part to test the `date-time` format preservation from Go. But some additional minor things were updated too. 

