### PR TITLE
feat: expand test coverage 

### DIFF
--- a/mock/Makefile
+++ b/mock/Makefile
@@ -1,5 +1,3 @@
 build:
 	tinygo build -target wasi -o plugin.wasm main.go
 
-test:
-	extism call plugin.wasm greet --input "world" --wasi

--- a/mock/main.go
+++ b/mock/main.go
@@ -41,4 +41,22 @@ func reflectByteBufferHost(kPtr uint64) uint64 {
 	return kRet.Offset()
 }
 
+//go:export noInputWithOutputHost
+func noInputWithOutputHost() uint64 {
+	mem := pdk.AllocateString("noInputWithOutputHost")
+	return mem.Offset()
+}
+
+//go:export withInputNoOutputHost
+func withInputNoOutputHost(ptr uint64) {
+	mem := pdk.FindMemory(ptr)
+	data := string(mem.ReadBytes())
+	if data != "42" { // JSON-encoded string value from the caller
+		panic("failed to read expected value")
+	}
+}
+
+//go:export noInputNoOutputHost
+func noInputNoOutputHost() {}
+
 func main() {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "xtp-bindgen-test",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-test": "^0.0.8"
+        "@dylibso/xtp-test": "^0.0.9"
       },
       "devDependencies": {
         "@extism/js-pdk": "^1.0.0",
@@ -18,9 +18,9 @@
       }
     },
     "node_modules/@dylibso/xtp-test": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-test/-/xtp-test-0.0.8.tgz",
-      "integrity": "sha512-XToSxuKdY4M2DFTPm09/6CtANeKmmNZyG8YLxS60bIRTmLV7mDyrILU+kXtCES5Ld041TGEtj3X1fXWNACRhzA=="
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-test/-/xtp-test-0.0.9.tgz",
+      "integrity": "sha512-FOw7/CgPfFHV3VmWEzqNbyuqjPcS+whvDNiuw66ODHBdlclybOe1JwJv5EMaYMoVgNYvMfJUDIox0Emttze9OQ=="
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/runner/package.json
+++ b/runner/package.json
@@ -15,6 +15,6 @@
     "@extism/js-pdk": "^1.0.0"
   },
   "dependencies": {
-    "@dylibso/xtp-test": "^0.0.8"
+    "@dylibso/xtp-test": "^0.0.9"
   }
 }

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -63,7 +63,7 @@ export function test() {
     // a string "noInputWithOutputHost" which it should return
     let noInputWithOutputOutput = Test.call(
       "noInputWithOutput",
-      "",
+      undefined,
     ).text();
     Test.assertEqual(
       "noInputWithOutput returns expected output",
@@ -92,7 +92,7 @@ export function test() {
       );
     }
 
-    const noInputNoOutput = Test.call("noInputNoOutput", "");
+    const noInputNoOutput = Test.call("noInputNoOutput", undefined);
     Test.assert(
       "noInputNoOutput is called successfully",
       noInputNoOutput.isEmpty(),

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -55,6 +55,45 @@ export function test() {
     inputB.byteLength,
   );
 
+  // should call a the `noInputWithOutputHost` host function passing it
+  // a string "noInputWithOutputHost" which it should return
+  let noInputWithOutputOutput = Test.callString(
+    "noInputWithOutput",
+    "",
+  );
+  Test.assertEqual(
+    "noInputWithOutput returns expected output",
+    noInputWithOutputOutput,
+    "noInputWithOutputHost",
+  );
+
+  // should call the `withInputNoOutputHost` host function passing it
+  // JSON-encoded number 42, which the host function checks for and panics
+  // if it is not that JSON value
+  try {
+    let withInputNoOutputOutput = Test.call(
+      "withInputNoOutput",
+      JSON.stringify(42),
+    );
+    Test.assertEqual(
+      "withInputNoOutput runs without panic",
+      withInputNoOutputOutput,
+      undefined,
+    );
+  } catch (e: any) {
+    Test.assert(
+      "withInputNoOutput runs without panic",
+      false,
+      `host function (withInputNoOutputHost) panic with unexpected argument, must be JSON-encoded 42: ${e.message}`,
+    );
+  }
+
+  Test.assertEqual(
+    "noInputNoOutput is called successfully",
+    Test.call("noInputNoOutput", ""),
+    undefined,
+  );
+
   return 0;
 }
 

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -25,7 +25,8 @@ const KitchenSink = {
 export function test() {
   Test.group("schema v1-draft encoding types", () => {
     let input = JSON.stringify(KitchenSink);
-    let output = JSON.parse(Test.callString("reflectJsonObject", input));
+    let output: typeof KitchenSink = Test.call("reflectJsonObject", input)
+      .json();
 
     matchIdenticalTopLevel(output);
     matchIdenticalEmbedded(output.anEmbeddedObject);
@@ -43,11 +44,11 @@ export function test() {
     );
 
     let inputS = KitchenSink.aString;
-    let outputS = Test.callString("reflectUtf8String", inputS);
+    let outputS = Test.call("reflectUtf8String", inputS).text();
     Test.assertEqual("reflectUtf8String preserved the string", outputS, inputS);
 
     let inputB = (new TextEncoder()).encode(KitchenSink.aString).buffer;
-    let outputB = Test.callBuffer("reflectByteBuffer", inputB);
+    let outputB = Test.call("reflectByteBuffer", inputB).arrayBuffer();
 
     // TODO compare the bytes
     Test.assertEqual(
@@ -60,10 +61,10 @@ export function test() {
   Test.group("check signature and type variations", () => {
     // should call a the `noInputWithOutputHost` host function passing it
     // a string "noInputWithOutputHost" which it should return
-    let noInputWithOutputOutput = Test.callString(
+    let noInputWithOutputOutput = Test.call(
       "noInputWithOutput",
       "",
-    );
+    ).text();
     Test.assertEqual(
       "noInputWithOutput returns expected output",
       noInputWithOutputOutput,
@@ -78,10 +79,10 @@ export function test() {
         "withInputNoOutput",
         JSON.stringify(42),
       );
-      Test.assertEqual(
-        "withInputNoOutput runs without panic",
-        withInputNoOutputOutput,
-        undefined,
+      Test.assert(
+        "withInputNoOutput runs and returns no output",
+        withInputNoOutputOutput.isEmpty(),
+        `expected empty output, got: ${withInputNoOutputOutput.text()}`,
       );
     } catch (e: any) {
       Test.assert(
@@ -91,10 +92,11 @@ export function test() {
       );
     }
 
-    Test.assertEqual(
+    const noInputNoOutput = Test.call("noInputNoOutput", "");
+    Test.assert(
       "noInputNoOutput is called successfully",
-      Test.call("noInputNoOutput", ""),
-      undefined,
+      noInputNoOutput.isEmpty(),
+      `expected empty output, got: ${noInputNoOutput.text()}`,
     );
   });
 

--- a/schema.yaml
+++ b/schema.yaml
@@ -89,6 +89,34 @@ exports:
       contentType: application/x-binary
       type: buffer
       description: The output byte buffer
+
+  noInputWithOutput:
+    description: a function that takes no input, but returns an output
+    output:
+      contentType: text/plain; charset=utf-8
+      type: string
+    codeSamples:
+    - lang: zig
+      source: |-
+        return Host.noInputWithOutputHost();
+
+  withInputNoOutput:
+    description: a function that takes input, but returns no output
+    input:
+      contentType: application/json
+      type: number
+    codeSamples:
+    - lang: zig
+      source: |-
+        return Host.withInputNoOutputHost(input);
+
+  noInputNoOutput:
+    description: a function that takes no input, and returns no output
+    codeSamples:
+    - lang: zig
+      source: |-
+        return Host.noInputNoOutputHost();
+
 imports:
   reflectJsonObjectHost:
     description: |
@@ -125,6 +153,22 @@ imports:
       contentType: application/x-binary
       type: buffer
       description: The output byte buffer
+
+  noInputWithOutputHost:
+    description: a function that takes no input, but returns an output
+    output:
+      contentType: text/plain; charset=utf-8
+      type: string
+
+  withInputNoOutputHost:
+    description: a function that takes input, but returns no output
+    input:
+      contentType: application/json
+      type: number
+
+  noInputNoOutputHost:
+    description: a function that takes no input, and returns no output
+
 components:
   schemas:
     EmbeddedObject:

--- a/schema.yaml
+++ b/schema.yaml
@@ -5,24 +5,24 @@ exports:
       This function takes a KitchenSinkObject and returns a KitchenSinkObject.
       It should come out the same way it came in.
     codeSamples:
-    - lang: typescript
-      source: |
-        // pass this through the host function and return it back
-        return reflectJsonObjectHost(input)
-    - lang: go
-      source: |-
-        reflect, err := ReflectJsonObjectHost(input)
-        if err != nil {
-          return KitchenSinkObject{}, err
-        }
+      - lang: typescript
+        source: |
+          // pass this through the host function and return it back
+          return reflectJsonObjectHost(input)
+      - lang: go
+        source: |-
+          reflect, err := ReflectJsonObjectHost(input)
+          if err != nil {
+            return input, err
+          }
 
-        return *reflect, err
-    - lang: csharp
-      source: |-
-        return Host.ReflectJsonObjectHost(input);
-    - lang: zig
-      source: |
-        return Host.reflectJsonObjectHost(input);
+          return *reflect, err
+      - lang: csharp
+        source: |-
+          return Host.ReflectJsonObjectHost(input);
+      - lang: zig
+        source: |
+          return Host.reflectJsonObjectHost(input);
     input:
       contentType: application/json
       $ref: "#/components/schemas/KitchenSinkObject"
@@ -34,23 +34,23 @@ exports:
       This function takes a string and returns it.
       Should come out the same way it came in.
     codeSamples:
-    - lang: typescript
-      source: |
-        return reflectUtf8StringHost(input)
-    - lang: go
-      source: |-
-        reflect, err := ReflectUtf8StringHost(input)
-        if err != nil {
-          return "", err
-        }
+      - lang: typescript
+        source: |
+          return reflectUtf8StringHost(input)
+      - lang: go
+        source: |-
+          reflect, err := ReflectUtf8StringHost(input)
+          if err != nil {
+            return "", err
+          }
 
-        return *reflect, nil
-    - lang: csharp
-      source: |-
-        return Host.ReflectUtf8StringHost(input);
-    - lang: zig
-      source: |
-        return Host.reflectUtf8StringHost(input);
+          return *reflect, nil
+      - lang: csharp
+        source: |-
+          return Host.ReflectUtf8StringHost(input);
+      - lang: zig
+        source: |
+          return Host.reflectUtf8StringHost(input);
     input:
       type: string
       description: The input string
@@ -64,23 +64,23 @@ exports:
       This function takes a byte buffer and returns it.
       Should come out the same way it came in.
     codeSamples:
-    - lang: typescript
-      source: |
-        return reflectByteBufferHost(input)
-    - lang: go
-      source: |-
-        reflect, err := ReflectByteBufferHost(input)
-        if err != nil {
-          return nil, err
-        }
+      - lang: typescript
+        source: |
+          return reflectByteBufferHost(input)
+      - lang: go
+        source: |-
+          reflect, err := ReflectByteBufferHost(input)
+          if err != nil {
+            return nil, err
+          }
 
-        return reflect, nil
-    - lang: csharp
-      source: |-
-        return Host.ReflectByteBufferHost(input);
-    - lang: zig
-      source: |
-        return Host.reflectByteBufferHost(input);
+          return reflect, nil
+      - lang: csharp
+        source: |-
+          return Host.ReflectByteBufferHost(input);
+      - lang: zig
+        source: |
+          return Host.reflectByteBufferHost(input);
     input:
       contentType: application/x-binary
       type: buffer
@@ -96,9 +96,20 @@ exports:
       contentType: text/plain; charset=utf-8
       type: string
     codeSamples:
-    - lang: zig
-      source: |-
-        return Host.noInputWithOutputHost();
+      - lang: typescript
+        source: |
+          return noInputWithOutputHost();
+      - lang: zig
+        source: |-
+          return Host.noInputWithOutputHost();
+      - lang: go
+        source: |
+          output, err := NoInputWithOutputHost()
+          if err != nil {
+            return *output, err
+          }
+
+          return *output, nil
 
   withInputNoOutput:
     description: a function that takes input, but returns no output
@@ -106,16 +117,32 @@ exports:
       contentType: application/json
       type: number
     codeSamples:
-    - lang: zig
-      source: |-
-        return Host.withInputNoOutputHost(input);
+      - lang: typescript
+        source: |
+          return withInputNoOutputHost(input);
+      - lang: zig
+        source: |-
+          return Host.withInputNoOutputHost(input);
+      - lang: go
+        source: |
+          err := WithInputNoOutputHost(input)
+          if err != nil {
+            return err
+          }
+          return nil
 
   noInputNoOutput:
     description: a function that takes no input, and returns no output
     codeSamples:
-    - lang: zig
-      source: |-
-        return Host.noInputNoOutputHost();
+      - lang: typescript
+        source: |-
+          noInputNoOutputHost();
+      - lang: zig
+        source: |-
+          return Host.noInputNoOutputHost();
+      - lang: go
+        source: |
+          return NoInputNoOutputHost()
 
 imports:
   reflectJsonObjectHost:
@@ -202,9 +229,9 @@ components:
       description: A string enum
       type: string
       enum:
-      - option1
-      - option2
-      - option3
+        - option1
+        - option2
+        - option3
     KitchenSinkObject:
       description: A json object with every type of property
       properties:


### PR DESCRIPTION
This expands on the existing test, covering some more minor cases where imports/exports have less typical signatures (no input, no output, etc) and some different types combined with encodings. 

NOTE: this is in draft until we release a new version of the `extism-js` compiler, [which includes a modification](https://github.com/extism/js-pdk/pull/92) to return `undefined` for a MemoryHandle rather than throwing an exception in a certain case. This was required so that tests could check for empty return values.

Should merge after:
- [x] released extism-js https://github.com/extism/js-pdk/releases/tag/v1.1.0
- [x] update to leverage https://github.com/dylibso/xtp-test-js/pull/12

Impacts bindgens: 
- [x] https://github.com/dylibso/xtp-typescript-bindgen/pull/20
- [x] https://github.com/dylibso/xtp-zig-bindgen/pull/2
- [x] https://github.com/dylibso/xtp-go-bindgen/pull/13
- [ ] (c# @mhmd-azeez)
- [ ] (c++ @G4Vi)
- [ ] (rust @zshipko)