### PR TITLE
feat: test for json+buffer combination roundtrip integrity

### DIFF
--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -12,7 +12,7 @@
         "@dylibso/xtp-test": "^0.0.9"
       },
       "devDependencies": {
-        "@extism/js-pdk": "^1.0.0",
+        "@extism/js-pdk": "^1.1.1",
         "esbuild": "^0.19.6",
         "typescript": "^5.3.2"
       }
@@ -391,10 +391,13 @@
       }
     },
     "node_modules/@extism/js-pdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@extism/js-pdk/-/js-pdk-1.0.1.tgz",
-      "integrity": "sha512-YJWfHGeOuJnQw4V8NPNHvbSr6S8iDd2Ga6VEukwlRP7tu62ozTxIgokYw8i+rajD/16zz/gK0KYARBpm2qPAmQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@extism/js-pdk/-/js-pdk-1.1.1.tgz",
+      "integrity": "sha512-VZLn/dX0ttA1uKk2PZeR/FL3N+nA1S5Vc7E5gdjkR60LuUIwCZT9cYON245V4HowHlBA7YOegh0TLjkx+wNbrA==",
+      "dev": true,
+      "dependencies": {
+        "urlpattern-polyfill": "^8.0.2"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.19.12",
@@ -446,6 +449,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-8.0.2.tgz",
+      "integrity": "sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==",
+      "dev": true
     }
   }
 }

--- a/runner/package.json
+++ b/runner/package.json
@@ -12,7 +12,7 @@
   "devDependencies": {
     "esbuild": "^0.19.6",
     "typescript": "^5.3.2",
-    "@extism/js-pdk": "^1.0.0"
+    "@extism/js-pdk": "^1.1.1"
   },
   "dependencies": {
     "@dylibso/xtp-test": "^0.0.9"

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -8,6 +8,9 @@ const EmbeddedObject = {
   aDate: "2024-07-23T16:03:34.000Z",
 };
 
+const inputBufferString = "Hello 🌍 World!🌍";
+const expectedOutputBufferString = "Goodbye 🌍 World!🌍";
+
 const KitchenSink = {
   anOptionalString: null,
   aString: "🌍Hello 🌍 World!🌍",
@@ -20,6 +23,12 @@ const KitchenSink = {
   anEmbeddedObject: EmbeddedObject,
   anEmbeddedObjectArray: [EmbeddedObject, EmbeddedObject],
   aDate: "2024-07-23T16:03:34.000Z",
+  // the host is expected to convert `buffer` type properties to base64 strings (like the below),
+  // but the bindgen'd XTP PDKs will handle this automatically, decoding base64 back to
+  // the original buffer.
+  aBuffer: Host.arrayBufferToBase64(
+    new TextEncoder().encode(inputBufferString).buffer,
+  ),
 };
 
 export function test() {
@@ -55,6 +64,13 @@ export function test() {
       "reflectByteBuffer preserved the buffer length",
       outputB.byteLength,
       inputB.byteLength,
+    );
+
+    output = Test.call("helloToGoodbyeReplacement", input).json();
+    Test.assertEqual(
+      "helloToGoodbyeReplacement properly converted, replaced, and reconverted data",
+      new TextDecoder().decode(Host.base64ToArrayBuffer(output.aBuffer)),
+      expectedOutputBufferString,
     );
   });
 

--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -29,6 +29,7 @@ const KitchenSink = {
   aBuffer: Host.arrayBufferToBase64(
     new TextEncoder().encode(inputBufferString).buffer,
   ),
+  // aBuffer: "NzIsMTAxLDEwOCwxMDgsMTExLDMyLDI0MCwxNTksMTQwLDE0MSwzMiw4NywxMTEsMTE0LDEwOCwxMDAsMzMsMjQwLDE1OSwxNDAsMTQx",
 };
 
 export function test() {
@@ -66,12 +67,18 @@ export function test() {
       inputB.byteLength,
     );
 
-    output = Test.call("helloToGoodbyeReplacement", input).json();
-    Test.assertEqual(
-      "helloToGoodbyeReplacement properly converted, replaced, and reconverted data",
-      new TextDecoder().decode(Host.base64ToArrayBuffer(output.aBuffer)),
-      expectedOutputBufferString,
-    );
+    const name =
+      "helloToGoodbyeReplacement properly converted, replaced, and reconverted data";
+    try {
+      output = Test.call("helloToGoodbyeReplacement", input).json();
+      Test.assertEqual(
+        name,
+        new TextDecoder().decode(Host.base64ToArrayBuffer(output.aBuffer)),
+        expectedOutputBufferString,
+      );
+    } catch (e: any) {
+      Test.assert(name, false, e.message);
+    }
   });
 
   Test.group("check signature and type variations", () => {

--- a/schema.yaml
+++ b/schema.yaml
@@ -161,6 +161,23 @@ exports:
       - lang: rust
         source: |
           pdk::no_input_no_output_host()
+  
+  helloToGoodbyeReplacement:
+    description: a function that should replace `Hello` with `Goodbye` within a byte buffer field on KitchenSinkObject
+    input:
+      contentType: application/json
+      $ref: "#/components/schemas/KitchenSinkObject"
+    output:
+      contentType: application/json
+      $ref: "#/components/schemas/KitchenSinkObject"
+    codeSamples:
+      - lang: go
+        source: |-
+          old := []byte("Hello")
+          new := []byte("Goodbye")
+          input.ABuffer = append(new, input.ABuffer[len(old):]...)
+
+          return input, nil
 
 imports:
   reflectJsonObjectHost:
@@ -292,3 +309,6 @@ components:
           description: a date
           type: string
           format: date-time
+        aBuffer:
+          description: a byte buffer
+          type: buffer

--- a/schema.yaml
+++ b/schema.yaml
@@ -198,6 +198,18 @@ exports:
           let mut output = _input;
           output.a_buffer = std::str::from_utf8(&output.a_buffer)?.replace("Hello", "Goodbye").as_bytes().to_vec();
           Ok(output)
+      - lang: zig
+        source: |-
+          const std = @import("std");
+          var output = input;
+          const old = "Hello";
+          const new = "Goodbye";
+          var arr = std.ArrayList(u8).init(std.heap.wasm_allocator);
+
+          try arr.insertSlice(0, new);
+          try arr.insertSlice(new.len, input.aBuffer[old.len..]);
+          output.aBuffer = try arr.toOwnedSlice();
+          return output;
 
 imports:
   reflectJsonObjectHost:

--- a/schema.yaml
+++ b/schema.yaml
@@ -122,6 +122,9 @@ exports:
       - lang: rust
         source: |
           pdk::no_input_with_output_host()
+      - lang: csharp
+        source: |-
+          return Host.NoInputWithOutputHost();
 
   withInputNoOutput:
     description: a function that takes input, but returns no output
@@ -145,6 +148,9 @@ exports:
       - lang: rust
         source: |
           pdk::with_input_no_output_host(_input)
+      - lang: csharp
+        source: |-
+          Host.WithInputNoOutputHost(input);
 
   noInputNoOutput:
     description: a function that takes no input, and returns no output
@@ -161,6 +167,9 @@ exports:
       - lang: rust
         source: |
           pdk::no_input_no_output_host()
+      - lang: csharp
+        source: |-
+          Host.NoInputNoOutputHost();
   
   helloToGoodbyeReplacement:
     description: a function that should replace `Hello` with `Goodbye` within a byte buffer field on KitchenSinkObject

--- a/schema.yaml
+++ b/schema.yaml
@@ -193,6 +193,11 @@ exports:
           buffer = buffer.Replace("Hello", "Goodbye");
           input.ABuffer = System.Text.Encoding.UTF8.GetBytes(buffer);
           return input;
+      - lang: rust
+        source: |-
+          let mut output = _input;
+          output.a_buffer = std::str::from_utf8(&output.a_buffer)?.replace("Hello", "Goodbye").as_bytes().to_vec();
+          Ok(output)
 
 imports:
   reflectJsonObjectHost:

--- a/schema.yaml
+++ b/schema.yaml
@@ -178,6 +178,12 @@ exports:
           input.ABuffer = append(new, input.ABuffer[len(old):]...)
 
           return input, nil
+      - lang: csharp
+        source: |-
+          var buffer = System.Text.Encoding.UTF8.GetString(input.ABuffer);
+          buffer = buffer.Replace("Hello", "Goodbye");
+          input.ABuffer = System.Text.Encoding.UTF8.GetBytes(buffer);
+          return input;
 
 imports:
   reflectJsonObjectHost:


### PR DESCRIPTION
I've tested this manually with the existing `xtp-go-bindgen` templates and it works as expected.. the rest of the languages need some source in the `codeSamples`, which should reflect the behavior of this Go sample: 

```go
old := []byte("Hello")
new := []byte("Goodbye")

input.ABuffer = append(new, input.ABuffer[len(old):]...)

return input, nil
```

Which effectively replaces the `Hello` with `Goodbye` within the byte slice auto-converted from the base64 string on the input param. 