### PR TITLE
fix: float comparision by casting values to float32 first

### DIFF
--- a/runner/src/index.ts
+++ b/runner/src/index.ts
@@ -122,6 +122,9 @@ const matchIdenticalTopLevel = (output: any) => {
     if (key === "anUntypedObject") {
       actual = JSON.stringify(actual);
       expected = JSON.stringify(expected);
+    } else if (key === 'aFloat') {
+      actual = (new Float32Array([actual]))[0];
+      expected = (new Float32Array([expected as number]))[0];
     }
     Test.assertEqual(
       `reflectJsonObject preserved identical value '${key}'`,


### PR DESCRIPTION
Different JSON encoders / languages serialize floats differently which have different values when casted to double (decoded into a a js `Number`). We can smooth out these differences by casting the values to float32 and back.

For example: `3.14` stays `3.14` through Go, but though C++ jsoncons it's now `3.140000104904175`, neither representation of 3.14 is wrong, they're both shorter than the value actually stored in the float: `3.1400001049041748046875`, however, they cast to different doubles.