### PR TITLE
chore: remove redundant std import in codeSample

### DIFF
--- a/schema.yaml
+++ b/schema.yaml
@@ -249,7 +249,6 @@ exports:
           Ok(output)
       - lang: zig
         source: |-
-          const std = @import("std");
           var output = input;
           const old = "Hello";
           const new = "Goodbye";


### PR DESCRIPTION
Kind of a strange one, as I'm not sure what changed to make this redundant.. but since it shadows the top-level import, Zig wont compile the generated code using this code sample. 

In any case, this fixes the test.