### PR TITLE
chore: update xtp-test-js

### DIFF
--- a/runner/package-lock.json
+++ b/runner/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@dylibso/xtp-test": "^0.0.9"
+        "@dylibso/xtp-test": "^0.0.10"
       },
       "devDependencies": {
         "@extism/js-pdk": "^1.1.1",
@@ -18,9 +18,10 @@
       }
     },
     "node_modules/@dylibso/xtp-test": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@dylibso/xtp-test/-/xtp-test-0.0.9.tgz",
-      "integrity": "sha512-FOw7/CgPfFHV3VmWEzqNbyuqjPcS+whvDNiuw66ODHBdlclybOe1JwJv5EMaYMoVgNYvMfJUDIox0Emttze9OQ=="
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@dylibso/xtp-test/-/xtp-test-0.0.10.tgz",
+      "integrity": "sha512-3bi0mm7CaxDra5nShIKrgaeGXIBDMJmD3xS2fuxbfGo1LPNHgLnJsMqtIVbKIP8xCdRJ8KUouGvZw43ALz3EgQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.19.12",

--- a/runner/package.json
+++ b/runner/package.json
@@ -15,6 +15,6 @@
     "@extism/js-pdk": "^1.1.1"
   },
   "dependencies": {
-    "@dylibso/xtp-test": "^0.0.9"
+    "@dylibso/xtp-test": "^0.0.10"
   }
 }


### PR DESCRIPTION
This makes sure we get meaningful error messages when a plugin call panics and the test library tries to deserialize it as json, see: https://github.com/dylibso/xtp-test-js/blob/b208619cbc8f49946d85e7c228ac9b6b7f8c77e6/index.ts#L41

Useful for scenarios like this:
```
 2025/01/12 17:05:40 Calling function : reflectJsonObject
Error: Uncaught SyntaxError: unexpected token: 'Panic'
    at <input>:1
    at parse (native)
    at json (script.js:50)
    at <anonymous> (script.js:242)
    at group (script.js:155)
    at test (script.js:273)
```